### PR TITLE
Fix compatibility with HTitle extension under Linux

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -472,6 +472,8 @@ var windowListener = {
 			aDOMWindow.document.documentElement.removeAttribute("tabsintitlebar"); // show a native titlebar like in Safari
 			aDOMWindow.updateTitlebarDisplay();
 		} else { // Linux
+		    // Set tab position to buttom to fix compatibility with certain extensions
+		    navBar.setAttribute('default-tabs-position', 'bottom')
 			// here we are concerned only with STATE_FULLSCREEN:
 			switch (aDOMWindow.windowState) {
 				case aDOMWindow.STATE_FULLSCREEN:


### PR DESCRIPTION
This pull request simply sets the "default-tabs-position" navBar attribute to 'bottom' to make the HTitle extension render its window controls in the correct place.
