### PR TITLE
Proposed fix for issue #41

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1022,6 +1022,11 @@ var windowListener = {
 					} else {
 						toolbarbtn.setAttribute('image', g.tabs[i].image || 'chrome://mozapps/skin/places/defaultFavicon.png');
 					}
+					if (g.tabs[i].hasAttribute('titlechanged')) {
+						toolbarbtn.setAttribute('titlechanged', 'true');
+					} else {
+						toolbarbtn.removeAttribute('titlechanged');
+					}
 				}
 				g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
 			}, // redrawToolbarbuttons: function() {

--- a/skin/tt-TabsToolbar.css
+++ b/skin/tt-TabsToolbar.css
@@ -11,3 +11,14 @@ window[tabsintitlebar="true"][sizemode="maximized"] #toolbar-menubar { /* [tabsi
 	margin-top: 27px; /* hack in order to TabsInTitlebar._update(true) to work properly (fires 'if (tabAndMenuHeight > titlebarContentHeight)') */
 	visibility: collapse;
 }
+
+#tt-toolbar > toolbarbutton {
+	-moz-appearance: none; /* This is needed to permit changing the background of the buttons */
+}
+
+#tt-toolbar > toolbarbutton[titlechanged] {
+	background-image: radial-gradient(farthest-corner at center bottom , rgb(255, 255, 255) 3%, rgba(186, 221, 251, 0.75) 20%, rgba(127, 179, 255, 0.25) 40%, transparent 70%);
+	background-position:  center bottom var(--tab-toolbar-navbar-overlap);
+	background-repeat: no-repeat;
+	background-size: 85% 100%;
+}


### PR DESCRIPTION
Detect the titlechanged attribute on pinned tabs and propagate it to the respective toolbar buttons.

The CSS rules may not be the best way to make this attribute visible to the user, but visually at least, it has the effect I wanted to achieve.
