### PR TITLE
Insert tabs at the top instead of the bottom of a tree if insertRelatedAfterCurrent is set

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1163,13 +1163,15 @@ var windowListener = {
 						} else {
 							let lvl = parseInt(ss.getTabValue(oldTab, 'ttLevel')) + 1;
 							let maxLvl = Services.prefs.getIntPref('extensions.tabtree.max-indent');
+							let insertRelatedAfterCurrent = Services.prefs.getBoolPref('browser.tabs.insertRelatedAfterCurrent');
 							let i;
 							if (maxLvl !== -1 && lvl > maxLvl) {
 								lvl = maxLvl;
 							}
 							ss.setTabValue(tab, 'ttLevel', lvl.toString());
+
 							for (i = oldTab._tPos + 1; i < g.tabs.length - 1; ++i) { // the last is our new tab
-								if (parseInt(ss.getTabValue(g.tabs[i], 'ttLevel')) < lvl) {
+								if (insertRelatedAfterCurrent || parseInt(ss.getTabValue(g.tabs[i], 'ttLevel')) < lvl) {
 									g.moveTabTo(tab, i);
 									break;
 								}

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1164,21 +1164,14 @@ var windowListener = {
 							let lvl = parseInt(ss.getTabValue(oldTab, 'ttLevel')) + 1;
 							let maxLvl = Services.prefs.getIntPref('extensions.tabtree.max-indent');
 							let i;
-							if (maxLvl === -1 || lvl <= maxLvl) {
-								ss.setTabValue(tab, 'ttLevel', lvl.toString());
-								for (i = oldTab._tPos + 1; i < g.tabs.length - 1; ++i) { // the last is our new tab
-									if (parseInt(ss.getTabValue(g.tabs[i], 'ttLevel')) < lvl) {
-										g.moveTabTo(tab, i);
-										break;
-									}
-								}
-							} else {
-								ss.setTabValue(tab, 'ttLevel', maxLvl.toString());
-								for (i = oldTab._tPos + 1; i < g.tabs.length - 1; ++i) { // the last is our new tab
-									if (parseInt(ss.getTabValue(g.tabs[i], 'ttLevel')) < maxLvl) {
-										g.moveTabTo(tab, i);
-										break;
-									}
+							if (maxLvl !== -1 && lvl > maxLvl) {
+								lvl = maxLvl;
+							}
+							ss.setTabValue(tab, 'ttLevel', lvl.toString());
+							for (i = oldTab._tPos + 1; i < g.tabs.length - 1; ++i) { // the last is our new tab
+								if (parseInt(ss.getTabValue(g.tabs[i], 'ttLevel')) < lvl) {
+									g.moveTabTo(tab, i);
+									break;
 								}
 							}
 


### PR DESCRIPTION
As suggested in #19, it should be possible to have new tabs open at the top of a tree.
