### PR TITLE
[Feature] tab tree in Firefox's sidebar

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -239,6 +239,7 @@ var windowListener = {
 		}
 		let sidebar = aDOMWindow.document.querySelector('#tt-sidebar');
 		ss.setWindowValue(aDOMWindow, 'tt-width', sidebar.width); // Remember the width of 'tt-sidebar'
+		ss.setWindowValue(aDOMWindow, 'tt-height', sidebar.height); // Remember the height of 'tt-sidebar'
 		// Remember the first visible row of the <tree id="tt">:
 		ss.setWindowValue(aDOMWindow, 'tt-first-visible-row', aDOMWindow.document.querySelector('#tt').treeBoxObject.getFirstVisibleRow().toString());
 		Services.prefs.removeObserver('extensions.tabtree.', aDOMWindow.tt.toRemove.prefsObserver); // it can also be removed in 'unloadFromWindow'
@@ -282,6 +283,7 @@ var windowListener = {
 		if (splitter) {
 			let sidebar = aDOMWindow.document.querySelector('#tt-sidebar');
 			ss.deleteWindowValue(aDOMWindow, 'tt-width', sidebar.width); // Restore the width of 'tt-sidebar' to 200px
+			ss.deleteWindowValue(aDOMWindow, 'tt-height', sidebar.height); // Restore the height of 'tt-sidebar' to 400px
 			splitter.parentNode.removeChild(splitter);
 			sidebar.parentNode.removeChild(sidebar);
 			let fullscrToggler = aDOMWindow.document.querySelector('#tt-fullscr-toggler');
@@ -345,6 +347,9 @@ var windowListener = {
 		}
 		let g = aDOMWindow.gBrowser;
 		let appcontent = aDOMWindow.document.querySelector('#appcontent');
+		let sidebar_browser = aDOMWindow.document.querySelector('#sidebar');
+		let sidebar_box = aDOMWindow.document.querySelector('#sidebar-box');
+		let sidebar_header = aDOMWindow.document.querySelector('#sidebar-header');
 		aDOMWindow.tt = {
 			toRemove: {eventListeners: {}, prefsObserver: null, tabsProgressListener: null, _menuObserver: null, sidebarWidthObserver: null},
 			toRestore: {g: {}, TabContextMenu: {}, tabsintitlebar: true}
@@ -546,7 +551,8 @@ var windowListener = {
 		let sidebar = aDOMWindow.document.createElement('vbox');
 		propsToSet = {
 			id: 'tt-sidebar',
-			width: ss.getWindowValue(aDOMWindow, 'tt-width') || ss.getGlobalValue('tt-new-sidebar-width') || '200'
+			width: ss.getWindowValue(aDOMWindow, 'tt-width') || ss.getGlobalValue('tt-new-sidebar-width') || '200',
+			height: ss.getWindowValue(aDOMWindow, 'tt-height') || ss.getGlobalValue('tt-new-sidebar-height') || '400'
 			//persist: 'width' // It seems 'persist' attr doesn't work in bootstrap addons, I'll use SS instead
 		};
 		Object.keys(propsToSet).forEach( (p)=>{sidebar.setAttribute(p, propsToSet[p])} );
@@ -563,20 +569,34 @@ var windowListener = {
 		Object.keys(propsToSet).forEach( (p)=>{splitter.setAttribute(p, propsToSet[p]);} );
 		// added later
 		//////////////////// END SPLITTER ///////////////////////////////////////////////////////////////////////
+
+		let setTTPos = function (aPos) {
+			switch (aPos) {
+				case TT_POS_SB_TOP:
+					sidebar_box.insertBefore(splitter, sidebar_header);
+					sidebar_box.insertBefore(sidebar, splitter);
+					sidebar_box.insertBefore(fullscrToggler, sidebar);
+					break;
+				case TT_POS_SB_BOT:
+					sidebar_box.appendChild(splitter);
+					sidebar_box.appendChild(sidebar);
+					sidebar_box.appendChild(fullscrToggler);
+					break;
+				case TT_POS_RIGHT:
+					browser.appendChild(fullscrToggler);
+					browser.appendChild(splitter);
+					browser.appendChild(sidebar);
+					break;
+				case TT_POS_LEFT:
+				default:
+					browser.insertBefore(fullscrToggler, appcontent);
+					browser.insertBefore(sidebar, appcontent);
+					browser.insertBefore(splitter, appcontent);
+					break;
+			}
+		};
+		setTTPos(Services.prefs.getIntPref('extensions.tabtree.position'));
 		
-		switch (Services.prefs.getIntPref('extensions.tabtree.position')) {
-			case TT_POS_RIGHT:
-				browser.appendChild(fullscrToggler);
-				browser.appendChild(splitter);
-				browser.appendChild(sidebar);
-				break;
-			case TT_POS_LEFT:
-			default:
-				browser.insertBefore(fullscrToggler, appcontent);
-				browser.insertBefore(sidebar, appcontent);
-				browser.insertBefore(splitter, appcontent);
-				break;
-		}
 
 		//////////////////// DROP INDICATOR ////////////////////////////////////////////////////////////////////////
 		let ind = aDOMWindow.document.getAnonymousElementByAttribute(aDOMWindow.gBrowser.tabContainer, 'anonid', 'tab-drop-indicator').cloneNode(true);
@@ -1998,15 +2018,7 @@ var windowListener = {
 							break;
 						case 'extensions.tabtree.position':
 							let firstVisibleRow = tree.treeBoxObject.getFirstVisibleRow();
-							if (Services.prefs.getIntPref('extensions.tabtree.position') === 1) {
-								browser.appendChild(fullscrToggler);
-								browser.appendChild(splitter);
-								browser.appendChild(sidebar);
-							} else {
-								browser.insertBefore(fullscrToggler, appcontent);
-								browser.insertBefore(sidebar, appcontent);
-								browser.insertBefore(splitter, appcontent);
-							}
+							setTTPos(Services.prefs.getIntPref('extensions.tabtree.position'));
 							tree.view = view;
 							tree.treeBoxObject.scrollToRow(firstVisibleRow);
 							tt.redrawToolbarbuttons();
@@ -2106,6 +2118,11 @@ var windowListener = {
 				if (mutation.attributeName == 'width') {
 					ss.setWindowValue(aDOMWindow, 'tt-width', sidebar.width); // Remember the width of 'tt-sidebar'
 					ss.setGlobalValue('tt-new-sidebar-width', sidebar.width);
+					return;
+				}
+				if (mutation.attributeName == 'height') {
+					ss.setWindowValue(aDOMWindow, 'tt-height', sidebar.height); // Remember the height of 'tt-sidebar'
+					ss.setGlobalValue('tt-new-sidebar-height', sidebar.height);
 					return;
 				}
 			}

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -578,22 +578,26 @@ var windowListener = {
 					sidebar_box.insertBefore(sidebar, splitter);
 					sidebar_box.insertBefore(fullscrToggler, sidebar);
 					splitter.setAttribute("resizeafter", "farthest");
+					splitter.setAttribute("orient", "vertical");
 					break;
 				case TT_POS_SB_BOT:
 					sidebar_box.appendChild(splitter);
 					sidebar_box.appendChild(sidebar);
 					sidebar_box.appendChild(fullscrToggler);
+					splitter.setAttribute("orient", "vertical");
 					break;
 				case TT_POS_RIGHT:
 					browser.appendChild(fullscrToggler);
 					browser.appendChild(splitter);
 					browser.appendChild(sidebar);
+					splitter.setAttribute("orient", "horizontal");
 					break;
 				case TT_POS_LEFT:
 				default:
 					browser.insertBefore(fullscrToggler, appcontent);
 					browser.insertBefore(sidebar, appcontent);
 					browser.insertBefore(splitter, appcontent);
+					splitter.setAttribute("orient", "horizontal");
 					break;
 			}
 		};

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -571,11 +571,13 @@ var windowListener = {
 		//////////////////// END SPLITTER ///////////////////////////////////////////////////////////////////////
 
 		let setTTPos = function (aPos) {
+			splitter.removeAttribute("resizeafter");
 			switch (aPos) {
 				case TT_POS_SB_TOP:
 					sidebar_box.insertBefore(splitter, sidebar_header);
 					sidebar_box.insertBefore(sidebar, splitter);
 					sidebar_box.insertBefore(fullscrToggler, sidebar);
+					splitter.setAttribute("resizeafter", "farthest");
 					break;
 				case TT_POS_SB_BOT:
 					sidebar_box.appendChild(splitter);

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -21,6 +21,11 @@ const sss = Cc["@mozilla.org/content/style-sheet-service;1"].getService(Ci.nsISt
 var stringBundle = Services.strings.createBundle('chrome://tabtree/locale/global.properties?' + Math.random()); // Randomize URI to work around bug 719376
 var prefsObserver;
 
+const TT_POS_LEFT = 0;
+const TT_POS_RIGHT = 1;
+const TT_POS_SB_TOP = 2;
+const TT_POS_SB_BOT = 3;
+
 //noinspection JSUnusedGlobalSymbols
 function startup(data, reason)
 {
@@ -513,6 +518,22 @@ var windowListener = {
 		//    <toolbox></toolbox>
 		//    <tree id="tt" flex="1" seltype="single" context="tabContextMenu" treelines="true" hidecolumnpicker="true"></tree>
 		//  </vbox>
+
+		//  for "sidebar top" position:
+		//  <vbox id="sidebar-box">
+		//    <vbox id="tt-sidebar"></vbox>
+		//    <splitter id="tt-splitter" />
+		//    <sidebarheader id="sidebar-header"></sidebarheader>
+		//    ...
+		//  </vbox>
+
+		//  for "sidebar bottom" position:
+		//  <vbox id="sidebar-box">
+		//     ...
+		//     <browser id="sidebar"></browser>
+		//     <splitter id="tt-splitter" />
+		//     <vbox id="tt-sidebar"></vbox>
+		//  </vbox>
 		
 		////////////////////////////////////////// VBOX tt-fullscr-toggler /////////////////////////////////////////////
 		// <vbox id="tt-fullscr-toggler"></vbox> // I am just copying what firefox does for its 'fullscr-toggler'
@@ -543,14 +564,18 @@ var windowListener = {
 		// added later
 		//////////////////// END SPLITTER ///////////////////////////////////////////////////////////////////////
 		
-		if (Services.prefs.getIntPref('extensions.tabtree.position') == 1) {
-			browser.appendChild(fullscrToggler);
-			browser.appendChild(splitter);
-			browser.appendChild(sidebar);
-		} else {
-			browser.insertBefore(fullscrToggler, appcontent);
-			browser.insertBefore(sidebar, appcontent);
-			browser.insertBefore(splitter, appcontent);
+		switch (Services.prefs.getIntPref('extensions.tabtree.position')) {
+			case TT_POS_RIGHT:
+				browser.appendChild(fullscrToggler);
+				browser.appendChild(splitter);
+				browser.appendChild(sidebar);
+				break;
+			case TT_POS_LEFT:
+			default:
+				browser.insertBefore(fullscrToggler, appcontent);
+				browser.insertBefore(sidebar, appcontent);
+				browser.insertBefore(splitter, appcontent);
+				break;
 		}
 
 		//////////////////// DROP INDICATOR ////////////////////////////////////////////////////////////////////////
@@ -849,7 +874,7 @@ var windowListener = {
 						g.moveTabTo(aTab, tPosTo);
 					}
 				}
-			}, // moveTabToPlus: function(aTab, tPosTo, mode) {
+			}, // moveTabToPlus: function(aTab, tPosTo, mode)
 
 			moveBranchToPlus: function(aTab, tPosTo, mode) {
 				let tPos = aTab._tPos;
@@ -936,7 +961,7 @@ var windowListener = {
 						g.moveTabTo(g.tabs[lastDescendantPos], tPosTo+1);
 					}
 				}
-			}, // moveBranchToPlus: function(aTab, tPosTo, mode) {
+			}, // moveBranchToPlus: function(aTab, tPosTo, mode)
 
 			lastDescendantPos: function(aTabOrPos) {
 				let ret;
@@ -1006,7 +1031,7 @@ var windowListener = {
 					}
 				}
 				g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
-			}, // redrawToolbarbuttons: function() {
+			}, // redrawToolbarbuttons: function()
 			
 			quickSearch: function(aText, tPos) {
 				// I assume that this method is never invoked with aText=''
@@ -1031,7 +1056,7 @@ var windowListener = {
 					aDOMWindow.document.documentElement.style.paddingLeft = '';
 				}, 500);
 			}
-		}; // let tt = {
+		}; // let tt =
 
 		treechildren.addEventListener('dragstart', function(event) { // if the event was attached to 'tree' then the popup would be shown while you scrolling
 			let tab = g.tabs[tree.currentIndex+tt.nPinned];
@@ -1124,7 +1149,7 @@ var windowListener = {
 			// uncomment if you always want to highlight 'gBrowser.mCurrentTab':
 			//g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
 			event.stopPropagation();
-		}, false); // tree.addEventListener('dragstart', function(event) {
+		}, false); // tree.addEventListener('dragstart', function(event)
 		
 		tree.addEventListener('dragend', function(event) {
 			if (event.dataTransfer.dropEffect == 'none') { // the drag was cancelled
@@ -1216,7 +1241,7 @@ var windowListener = {
 								tree.treeBoxObject.rowCountChanged(tab._tPos - tt.nPinned, 1);
 								// refresh the twisty (commented out while the twisty is disabled):
 								//let pTab = tt.parentTab(tab);
-								//if (pTab) {
+								//if (pTab)
 								//	tree.treeBoxObject.invalidateRow(pTab._tPos - tt.nPinned);
 								//}
 
@@ -1478,7 +1503,7 @@ var windowListener = {
 				}
 				g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
 			} // drop(row, orientation, dataTransfer)
-		}; // let view = {
+		}; // let view =
 		tree.view = view;
 
 		aDOMWindow.tt.toRestore.g.pinTab = g.pinTab;
@@ -2133,5 +2158,5 @@ var windowListener = {
 		//aDOMWindow.tt.sidebar = sidebar; // uncomment while debugging
 		//aDOMWindow.tt.customizer = aDOMWindow.document.getElementById("customization-container"); // uncomment while debugging
 		
-	} // loadIntoWindow: function(aDOMWindow) {
-}; // var windowListener = {
+	} // loadIntoWindow: function(aDOMWindow)
+}; // var windowListener =

--- a/locale/en-US/options.dtd
+++ b/locale/en-US/options.dtd
@@ -13,6 +13,8 @@
 <!ENTITY delay.desc "Actually it is a delay until a selected tab is displayed. Set it to around 160 if you don't want to see a tab flipping while closing a tab (0 by default)">
 <!ENTITY position.left "Left">
 <!ENTITY position.right "Right">
+<!ENTITY position.sidebar_top "In the sidebar (at the top)">
+<!ENTITY position.sidebar_bottom "In the sidebar (at the bottom)">
 <!ENTITY position.title "Position:">
 <!ENTITY position.desc "(&quot;Left&quot; by default)">
 <!ENTITY search-position.title "Tab search bar position:">

--- a/locale/fr-FR/options.dtd
+++ b/locale/fr-FR/options.dtd
@@ -13,6 +13,8 @@
 <!ENTITY delay.desc "En réalité, c’est le délai avant qu’un onglet sélectionné soit affiché. Mettez-le autour de 160 si vous ne voulez pas voir votre onglet changer pendant la fermeture de l’onglet (0 par défaut)">
 <!ENTITY position.left "Gauche">
 <!ENTITY position.right "Droite">
+<!ENTITY position.sidebar_top "Sidebar (top)">
+<!ENTITY position.sidebar_bottom "Sidebar (bottom)">
 <!ENTITY position.title "Position:">
 <!ENTITY position.desc "(&#171;Gauche&#187; par défaut)">
 <!ENTITY search-position.title "Position de la barre de recherche d’onglet:">

--- a/locale/pl-PL/options.dtd
+++ b/locale/pl-PL/options.dtd
@@ -13,6 +13,8 @@
 <!ENTITY delay.desc "W rzeczywistości jest to odstęp, zanim wybrana karta zostanie pokazana. Wpisz 160, jeśli nie chcesz widzieć mignięcia kart przy zamykaniu (domyślnie 0)">
 <!ENTITY position.left "Lewo">
 <!ENTITY position.right "Prawo">
+<!ENTITY position.sidebar_top "Sidebar (top)">
+<!ENTITY position.sidebar_bottom "Sidebar (bottom)">
 <!ENTITY position.title "Pozycja:">
 <!ENTITY position.desc "(Domyślnie &quot;lewo&quot;)">
 <!ENTITY search-position.title "Pozycja wyszukiwarki kart:">

--- a/locale/ru-RU/options.dtd
+++ b/locale/ru-RU/options.dtd
@@ -13,6 +13,8 @@
 <!ENTITY delay.desc "Задержка перед тем как выделенная вкладка активируется. Если вы не хотите видеть вкладку перед её закрытием, то установите это значение в 160 или больше (0 by default)">
 <!ENTITY position.left "Слева">
 <!ENTITY position.right "Справа">
+<!ENTITY position.sidebar_top "Sidebar (top)">
+<!ENTITY position.sidebar_bottom "Sidebar (bottom)">
 <!ENTITY position.title "Расположение:">
 <!ENTITY position.desc "(&quot;Слева&quot; по умолчанию)">
 <!ENTITY search-position.title "Расположение строки поиска вкладки:">

--- a/options.xul
+++ b/options.xul
@@ -22,11 +22,15 @@
     <setting type="bool" pref="extensions.tabtree.highlight-unread-tabs" title="&highlight-unread-tabs.title;" desc="&highlight-unread-tabs.desc;" />
     <setting type="bool" pref="extensions.tabtree.dblclick" title="&dblclick.title;" desc="&dblclick.desc;" onpreferencechanged="this.setAttribute('value', this.value.toString());" />
     <setting type="integer" pref="extensions.tabtree.delay" title="&delay.title;" desc="&delay.desc;" />
-    <setting type="radio" pref="extensions.tabtree.position" title="&position.title;" desc="&position.desc;">
-        <radiogroup>
-            <radio value="0" label="&position.left;"/>
-            <radio value="1" label="&position.right;"/>
-        </radiogroup>
+    <setting type="menulist" pref="extensions.tabtree.position" title="&position.title;" desc="&position.desc;">
+        <menulist>
+            <menupopup>
+                <menuitem value="0" label="&position.left;"/>
+                <menuitem value="1" label="&position.right;"/>
+                <menuitem value="2" label="&position.sidebar_top;"/>
+                <menuitem value="3" label="&position.sidebar_bottom;"/>
+            </menupopup>
+        </menulist>
     </setting>
     <setting type="menulist" pref="extensions.tabtree.search-position" title="&search-position.title;" desc="&search-position.desc;">
         <menulist>

--- a/skin/tt-other.css
+++ b/skin/tt-other.css
@@ -9,6 +9,10 @@
 	pointer-events: none; /* preventing the arrow flickering when mouse pointer goes over that arrow and that arrow overlaps 'toolbar' */
 }
 
+#tt-sidebar {
+	overflow: hidden;
+}
+
 /* Full screen mode */
 
 #tt-toolbar[moz-collapsed="true"] { /* do not collapse in fullscreen mode*/


### PR DESCRIPTION
It doesn't take much work to allow the tab tree to appear in Firefox's sidebar, above/below the bookmarks or whatever else is loaded in there.

When the sidebar is hidden (e.g. if you press Ctrl-B while the bookmarks sidebar is visible), so are the tabs. This means two things:
- Add-ons like all-in-one sidebar that shrink/hide the sidebar do their magic to the tab tree as well.
- People who don't use the sidebar normally shouldn't put the tab tree in it.

I changed the appropriate option on the settings page from a radio group to a menu, to keep it compact. Obviously the new options in this menu will need translations if you decide to accept this.

I'm still dogfooding this idea to see if complications arise, but I thought you might like to see it.
