### PR TITLE
Audio indicator work for issue #8

### DIFF
--- a/bindings.xml
+++ b/bindings.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+
+<bindings xmlns="http://www.mozilla.org/xbl"
+  xmlns:xbl="http://www.mozilla.org/xbl"
+  xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+
+  <binding id="toolbarbutton-overlay"
+    extends="chrome://global/content/bindings/toolbarbutton.xml#toolbarbutton">
+    <!-- Much inspiration taken from chrome://global/content/bindings/toolbarbutton.xml#toolbarbutton-badged -->
+
+    <content>
+      <children includes="observes|template|menupopup|panel|tooltip"/>
+      <xul:stack anonid="toolbarbutton-overlay-stack" class="toolbarbutton-overlay-stack">
+        <xul:image anonid="toolbarbutton-icon" class="toolbarbutton-icon" xbl:inherits="validate,src=image,label"/>
+        <xul:image anonid="toolbarbutton-overlay" class="toolbarbutton-overlay" xbl:inherits="overlay,tooltiptext=overlaytext" top="0" end="0"/>
+      </xul:stack>
+      <xul:label class="toolbarbutton-text" crop="right" flex="1" xbl:inherits="value=label,accesskey,crop,wrap"/>
+      <xul:label class="toolbarbutton-multiline-text" flex="1" xbl:inherits="value=label,accesskey,wrap"/>
+    </content>
+
+    <implementation>
+      <field name="mOverOverlay">false</field>
+      <property name="_overOverlayIcon" readonly="true">
+        <getter><![CDATA[
+          if (!this.hasAttribute("overlay")) return false;
+          let icon = document.getAnonymousElementByAttribute(this, 'anonid', 'toolbarbutton-overlay');
+          return icon && icon.mozMatchesSelector(":hover");
+        ]]></getter>
+      </property>
+      <method name="_overlayClick">
+        <parameter name="aEvent" />
+        <body><![CDATA[
+          if(this.mOverOverlay)
+          {
+            event.stopPropagation();
+            alert("woot");
+          }
+        ]]></body>
+      </method>
+    </implementation>
+
+    <handlers>
+      <handler event="mouseover"><![CDATA[
+        let anonid = event.originalTarget.getAttribute("anonid");
+        if(anonid == "toolbarbutton-overlay") this.mOverOverlay = true;
+      ]]></handler>
+      <handler event="mouseout"><![CDATA[
+        let anonid = event.originalTarget.getAttribute("anonid");
+        if(anonid == "toolbarbutton-overlay") this.mOverOverlay = false;
+      ]]></handler>
+      <handler phase="capturing" event="mousedown" button="0" action="this._overlayClick(event)"/>
+    </handlers>
+
+  </binding>
+
+</bindings>

--- a/bindings.xml
+++ b/bindings.xml
@@ -20,7 +20,7 @@
       <xul:stack>
         <xul:toolbarbutton anonid="button" class="tt-tab-button"
           xbl:inherits="accesskey,autocheck,checkState,checked,command,crop,dir,disabled,dlgtype,group,image,label,oncommand,open,orient,tabindex,title,type,validate,titlechanged"/>
-        <xul:image anonid="overlay" class="tt-tab-overlay" xbl:inherits="tooltiptext=overlaytext,overlay" top="0" end="0"/>
+        <xul:image anonid="overlay" class="tt-tab-overlay" xbl:inherits="tooltiptext=overlaytext,muted,soundplaying" top="0" end="0"/>
       </xul:stack>
     </content>
 
@@ -29,7 +29,72 @@
       <property name="_overlay" readonly="true" onget="return document.getAnonymousElementByAttribute(this, 'anonid', 'overlay');"/>
       <property name="checked" onget="return this.button.checked;" onset="this.button.checked = val;"/>
       <property name="image" onget="return this.button.getAttribute('image');" onset="val ? this.button.setAttribute('image','val') : this.button.removeAttribute('image')"/>
-      <property name="tPos" readonly="true" onget="return Array.prototype.indexOf.call(this.parentNode.children, this)-1;"/><!-- The first child is the arrow hbox -->
+
+      <field name="_tab">null</field>
+      <property name="tab">
+        <getter><![CDATA[
+          if(this._tab == null) throw "ttpinnedtab.tab get without set";
+          return this._tab;
+        ]]></getter>
+        <setter><![CDATA[
+          if (val.localName != 'tab') throw "invalid tab";
+          this._tab = val;
+          this.repaint();
+          return this._tab;
+        ]]></setter>
+      </property>
+      <property name="_browser" readonly="true">
+        <getter><![CDATA[
+          if(this._tab == null) throw "ttpinnedtab.tab get without set";
+          return this._tab.parentNode.tabbrowser;
+        ]]></getter>
+      </property>
+
+      <method name="repaint">
+        <body><![CDATA[
+          let tab = this._tab;
+          this.setAttribute('tooltiptext', tab.label);
+          this.setAttribute('type', 'radio');
+          this.setAttribute('group', 'RadioGroup');
+          this.setAttribute('context', 'tabContextMenu');
+          this.checked = tab.selected;
+
+          if (tab.hasAttribute('progress') && tab.hasAttribute('busy')) {
+            this.setAttribute('image', 'chrome://browser/skin/tabbrowser/loading.png');
+          } else if (this.tab.hasAttribute('busy')) {
+            this.setAttribute('image', 'chrome://browser/skin/tabbrowser/connecting.png');
+          } else {
+            this.setAttribute('image', tab.image || 'chrome://mozapps/skin/places/defaultFavicon.png');
+          }
+
+          let me = this; // javascript is funny sometimes
+          [
+            'titlechanged',
+            'muted',
+            'soundplaying',
+          ].forEach(function(x) {
+            if (tab.hasAttribute(x))
+              me.setAttribute(x, 'true');
+            else
+              me.removeAttribute(x);
+          });
+
+          // Taken from createTooltip() in chrome://browser/content/tabbrowser.xml
+          if (this.hasAttribute('muted') || this.hasAttribute('soundplaying')) {
+            let stringID = tab.linkedBrowser.audioMuted ?
+              "tabs.unmuteAudio.tooltip" :
+              "tabs.muteAudio.tooltip";
+            let key = document.getElementById("key_toggleMute");
+            let shortcut = ShortcutUtils.prettifyShortcut(key);
+            let label = this._browser.mStringBundle.getFormattedString(stringID, [shortcut]);
+            this.setAttribute('overlaytext', label);
+          } else {
+            this.removeAttribute('overlaytext');
+          }
+        ]]></body>
+      </method>
+
+      <property name="tPos" readonly="true" onget="return this.tab._tPos;"/>
       <property name="mOverOverlay" readonly="true">
         <getter><![CDATA[
         if(!this.hasAttribute("overlay")) return false;
@@ -38,16 +103,15 @@
       </property>
     </implementation>
 
-    <!--
     <handlers>
-      <handler phase="capturing" event="click"><![CDATA[
-        console.log("capturing: original target="+event.originalTarget.nodeName);
-      ]]></handler>
-      <handler phase="bubbling" event="click"><![CDATA[
-        console.log("bubbling: original target="+event.originalTarget.nodeName);
+      <handler event="command" action="if(this.tab) this._browser.selectTabAtIndex(this.tab._tPos)"/>
+      <handler event="click" button="0"><![CDATA[
+        if (event.originalTarget === this._overlay) {
+          event.stopPropagation();
+          this.tab.toggleMuteAudio();
+        }
       ]]></handler>
     </handlers>
-    -->
   </binding>
 
 </bindings>

--- a/bindings.xml
+++ b/bindings.xml
@@ -4,53 +4,50 @@
   xmlns:xbl="http://www.mozilla.org/xbl"
   xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-  <binding id="toolbarbutton-overlay"
-    extends="chrome://global/content/bindings/toolbarbutton.xml#toolbarbutton">
-    <!-- Much inspiration taken from chrome://global/content/bindings/toolbarbutton.xml#toolbarbutton-badged -->
+  <!-- This is just a toolbarbutton, with a few added methods to make our lives a bit easier -->
+  <binding id="ttbutton" extends="chrome://global/content/bindings/toolbarbutton.xml#toolbarbutton">
+    <implementation>
+      <!-- remember to keep this up to date with changes to ttpinnedtab's structure below -->
+      <property name="tPos" readonly="true" onget="return this.parentNode.parentNode.tPos;"/>
+    </implementation>
+  </binding>
 
+  <!-- element representing a pinned tab; contains the toolbarbutton itself and
+       an image that can be overlaid on it to show e.g. sound is playing -->
+  <binding id="ttpinnedtab">
     <content>
       <children includes="observes|template|menupopup|panel|tooltip"/>
-      <xul:stack anonid="toolbarbutton-overlay-stack" class="toolbarbutton-overlay-stack">
-        <xul:image anonid="toolbarbutton-icon" class="toolbarbutton-icon" xbl:inherits="validate,src=image,label"/>
-        <xul:image anonid="toolbarbutton-overlay" class="toolbarbutton-overlay" xbl:inherits="overlay,tooltiptext=overlaytext" top="0" end="0"/>
+      <xul:stack>
+        <xul:toolbarbutton anonid="button" class="tt-tab-button"
+          xbl:inherits="accesskey,autocheck,checkState,checked,command,crop,dir,disabled,dlgtype,group,image,label,oncommand,open,orient,tabindex,title,type,validate,titlechanged"/>
+        <xul:image anonid="overlay" class="tt-tab-overlay" xbl:inherits="tooltiptext=overlaytext,overlay" top="0" end="0"/>
       </xul:stack>
-      <xul:label class="toolbarbutton-text" crop="right" flex="1" xbl:inherits="value=label,accesskey,crop,wrap"/>
-      <xul:label class="toolbarbutton-multiline-text" flex="1" xbl:inherits="value=label,accesskey,wrap"/>
     </content>
 
     <implementation>
-      <field name="mOverOverlay">false</field>
-      <property name="_overOverlayIcon" readonly="true">
+      <property name="button" readonly="true" onget="return document.getAnonymousElementByAttribute(this, 'anonid', 'button');"/>
+      <property name="_overlay" readonly="true" onget="return document.getAnonymousElementByAttribute(this, 'anonid', 'overlay');"/>
+      <property name="checked" onget="return this.button.checked;" onset="this.button.checked = val;"/>
+      <property name="image" onget="return this.button.getAttribute('image');" onset="val ? this.button.setAttribute('image','val') : this.button.removeAttribute('image')"/>
+      <property name="tPos" readonly="true" onget="return Array.prototype.indexOf.call(this.parentNode.children, this)-1;"/><!-- The first child is the arrow hbox -->
+      <property name="mOverOverlay" readonly="true">
         <getter><![CDATA[
-          if (!this.hasAttribute("overlay")) return false;
-          let icon = document.getAnonymousElementByAttribute(this, 'anonid', 'toolbarbutton-overlay');
-          return icon && icon.mozMatchesSelector(":hover");
+        if(!this.hasAttribute("overlay")) return false;
+        return this._overlay && this._overlay.mozMatchesSelector(":hover");
         ]]></getter>
       </property>
-      <method name="_overlayClick">
-        <parameter name="aEvent" />
-        <body><![CDATA[
-          if(this.mOverOverlay)
-          {
-            event.stopPropagation();
-            alert("woot");
-          }
-        ]]></body>
-      </method>
     </implementation>
 
+    <!--
     <handlers>
-      <handler event="mouseover"><![CDATA[
-        let anonid = event.originalTarget.getAttribute("anonid");
-        if(anonid == "toolbarbutton-overlay") this.mOverOverlay = true;
+      <handler phase="capturing" event="click"><![CDATA[
+        console.log("capturing: original target="+event.originalTarget.nodeName);
       ]]></handler>
-      <handler event="mouseout"><![CDATA[
-        let anonid = event.originalTarget.getAttribute("anonid");
-        if(anonid == "toolbarbutton-overlay") this.mOverOverlay = false;
+      <handler phase="bubbling" event="click"><![CDATA[
+        console.log("bubbling: original target="+event.originalTarget.nodeName);
       ]]></handler>
-      <handler phase="capturing" event="mousedown" button="0" action="this._overlayClick(event)"/>
     </handlers>
-
+    -->
   </binding>
 
 </bindings>

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -627,7 +627,7 @@ var windowListener = {
 				<hbox align="start">
 					<img id="tt-drop-indicator" style="margin-top:-8px"/>
 				</hbox>
-				<ttpinnedtab />
+				<ttpinnedtab /> <!-- see bindings.xml -->
 				<ttpinnedtab />
 				<ttpinnedtab />
 				<ttpinnedtab />
@@ -1060,30 +1060,7 @@ var windowListener = {
 						toolbar.removeChild(pinnedtab);
 						continue;
 					}
-					pinnedtab.setAttribute('tooltiptext', g.tabs[i].label);
-					pinnedtab.setAttribute('type', 'radio');
-					pinnedtab.setAttribute('group', 'RadioGroup');
-					pinnedtab.setAttribute('context', 'tabContextMenu');
-					pinnedtab.checked = g.tabs[i].selected;
-					if (g.tabs[i].hasAttribute('progress') && g.tabs[i].hasAttribute('busy')) {
-						pinnedtab.setAttribute('image', 'chrome://browser/skin/tabbrowser/loading.png');
-					} else if (g.tabs[i].hasAttribute('busy')) {
-						pinnedtab.setAttribute('image', 'chrome://browser/skin/tabbrowser/connecting.png');
-					} else {
-						pinnedtab.setAttribute('image', g.tabs[i].image || 'chrome://mozapps/skin/places/defaultFavicon.png');
-					}
-					if (g.tabs[i].hasAttribute('titlechanged')) {
-						pinnedtab.setAttribute('titlechanged', 'true');
-					} else {
-						pinnedtab.removeAttribute('titlechanged');
-					}
-					if (g.tabs[i].hasAttribute('muted')) {
-						pinnedtab.setAttribute('overlay', 'muted');
-					} else if (g.tabs[i].hasAttribute('soundplaying')) {
-						pinnedtab.setAttribute('overlay', 'soundplaying');
-					} else {
-						pinnedtab.removeAttribute('overlay');
-					}
+					pinnedtab.tab = g.tabs[i]; // The XBL binding takes care of the details now
 				}
 				g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
 			}, // redrawToolbarbuttons: function()
@@ -1953,12 +1930,6 @@ var windowListener = {
 			tt.redrawToolbarbuttons();
 		}), false); // don't forget to remove
 		
-		toolbar.addEventListener('command', function f(event) {
-			if (event.originalTarget.localName == 'toolbarbutton') {
-				let tPos = event.originalTarget.tPos;
-				g.selectTabAtIndex(tPos);
-			}
-		}, false);
 
 		// "This event should be dispatched when any of these attributes change:
 		// label, crop, busy, image, selected" from 'tabbrowser.xml'

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -668,6 +668,7 @@ var windowListener = {
 			tabtitle: aDOMWindow.document.createElement('treecol'), // <treecol>
 			overlay:  aDOMWindow.document.createElement('treecol'), // <treecol>
 			closebtn: aDOMWindow.document.createElement('treecol'), // <treecol>
+			scrollbar: aDOMWindow.document.createElement('treecol'), // <treecol>
 		};
 		propsToSet = {
 			id: 'tt-title',
@@ -681,14 +682,14 @@ var windowListener = {
 		treecol.closebtn.setAttribute('hideheader', 'true');
 		treecol.closebtn.id = 'tt-close';
 		treecol.closebtn.collapsed = !Services.prefs.getBoolPref('extensions.tabtree.close-tab-buttons');
-		treecol.closebtn.collapsed
-			? tree.setAttribute("hideclosebuttons", "true")
-			: tree.removeAttribute("hideclosebuttons");
+		treecol.scrollbar.setAttribute('hideheader', 'true');
+		treecol.scrollbar.id = 'tt-scrollbar';
 		let treechildren = aDOMWindow.document.createElement('treechildren'); // <treechildren id="tt-treechildren">
 		treechildren.setAttribute('id', 'tt-treechildren');
 		treecols.appendChild(treecol.tabtitle);
 		treecols.appendChild(treecol.overlay);
 		treecols.appendChild(treecol.closebtn);
+		treecols.appendChild(treecol.scrollbar);
 		tree.appendChild(treecols);
 		tree.appendChild(treechildren);
 		sidebar.appendChild(tree);
@@ -2052,9 +2053,6 @@ var windowListener = {
 							break;
 						case 'extensions.tabtree.close-tab-buttons':
 							treecol.closebtn.collapsed = !Services.prefs.getBoolPref('extensions.tabtree.close-tab-buttons');
-							treecol.closebtn.collapsed
-								? tree.setAttribute("hideclosebuttons", "true")
-								: tree.removeAttribute("hideclosebuttons");
 							break;
 						case 'extensions.tabtree.dblclick':
 							if (Services.prefs.getBoolPref('extensions.tabtree.dblclick')) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -681,6 +681,9 @@ var windowListener = {
 		treecol.closebtn.setAttribute('hideheader', 'true');
 		treecol.closebtn.id = 'tt-close';
 		treecol.closebtn.collapsed = !Services.prefs.getBoolPref('extensions.tabtree.close-tab-buttons');
+		treecol.closebtn.collapsed
+			? tree.setAttribute("hideclosebuttons", "true")
+			: tree.removeAttribute("hideclosebuttons");
 		let treechildren = aDOMWindow.document.createElement('treechildren'); // <treechildren id="tt-treechildren">
 		treechildren.setAttribute('id', 'tt-treechildren');
 		treecols.appendChild(treecol.tabtitle);
@@ -1060,9 +1063,6 @@ var windowListener = {
 					toolbarbtn.setAttribute('group', 'RadioGroup');
 					toolbarbtn.setAttribute('context', 'tabContextMenu');
 					toolbarbtn.checked = g.tabs[i].selected;
-					let image = aDOMWindow.document.getAnonymousNodes(toolbarbtn)[0]; // there are sites with at least 32px*32px images therefore buttons would have become huge
-					image.setAttribute('height', '16px'); // we reduce such big images
-					image.setAttribute('width', '16px'); // also there are cases where the image is 60px*20px ('chrome://browser/skin/search-indicator.png' for example)
 					if (g.tabs[i].hasAttribute('progress') && g.tabs[i].hasAttribute('busy')) {
 						toolbarbtn.setAttribute('image', 'chrome://browser/skin/tabbrowser/loading.png');
 					} else if (g.tabs[i].hasAttribute('busy')) {
@@ -1074,6 +1074,13 @@ var windowListener = {
 						toolbarbtn.setAttribute('titlechanged', 'true');
 					} else {
 						toolbarbtn.removeAttribute('titlechanged');
+					}
+					if (g.tabs[i].hasAttribute('muted')) {
+						toolbarbtn.setAttribute('overlay', 'muted');
+					} else if (g.tabs[i].hasAttribute('soundplaying')) {
+						toolbarbtn.setAttribute('overlay', 'soundplaying');
+					} else {
+						toolbarbtn.removeAttribute('overlay');
 					}
 				}
 				g.mCurrentTab.pinned ? tree.view.selection.clearSelection() : tree.view.selection.select(g.mCurrentTab._tPos - tt.nPinned); // NEW
@@ -2045,6 +2052,9 @@ var windowListener = {
 							break;
 						case 'extensions.tabtree.close-tab-buttons':
 							treecol.closebtn.collapsed = !Services.prefs.getBoolPref('extensions.tabtree.close-tab-buttons');
+							treecol.closebtn.collapsed
+								? tree.setAttribute("hideclosebuttons", "true")
+								: tree.removeAttribute("hideclosebuttons");
 							break;
 						case 'extensions.tabtree.dblclick':
 							if (Services.prefs.getBoolPref('extensions.tabtree.dblclick')) {

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,4 +1,5 @@
 # content   tabtree 		content/
+content   tabtree 		.
 skin      tabtree classic/1.0	skin/
 locale    tabtree en-US locale/en-US/
 locale    tabtree ru-RU locale/ru-RU/

--- a/locale/en-US/global.properties
+++ b/locale/en-US/global.properties
@@ -1,3 +1,4 @@
 tabs_quick_search=Start typing to search for a tab
 close_this_tree=Tab Tree: Close this Tree
 close_children=Tab Tree: Close Children
+dbl_click_new_tab=Double-click to open a new tab

--- a/locale/fr-FR/global.properties
+++ b/locale/fr-FR/global.properties
@@ -1,3 +1,4 @@
 tabs_quick_search=Tapez pour chercher un onglet
 close_this_tree=Tab Tree: Close this Tree
 close_children=Tab Tree: Close Children
+dbl_click_new_tab=Double-click to open a new tab

--- a/locale/pl-PL/global.properties
+++ b/locale/pl-PL/global.properties
@@ -1,3 +1,4 @@
 tabs_quick_search=Zacznij pisać, żeby wyszukać kartę
 close_this_tree=Tab Tree: Zamknij to drzewo
 close_children=Tab Tree: Zamknij karty podrzędne
+dbl_click_new_tab=Double-click to open a new tab

--- a/locale/ru-RU/global.properties
+++ b/locale/ru-RU/global.properties
@@ -1,3 +1,4 @@
 tabs_quick_search=Поиск вкладки
 close_this_tree=Tab Tree: Закрыть это дерево
 close_children=Tab Tree: Закрыть дочерние вкладки
+dbl_click_new_tab=Double-click to open a new tab

--- a/skin/tt-TabsToolbar.css
+++ b/skin/tt-TabsToolbar.css
@@ -3,6 +3,9 @@
  * Copyright (C) 2015 Sergey Zelentsov <crayfishexterminator@gmail.com>
  */
 
+
+/* :::::: toolbar buttons :::::: */
+
 window[tabsintitlebar="true"][sizemode="maximized"] #toolbar-menubar { /* [tabsintitlebar="true"] is only on Windows */
 	padding-bottom: 1px; /* padding that causes #toolbar-menubar to change its height (from 19px to 18px) in Windows 7 at a window opening */
 }
@@ -13,6 +16,7 @@ window[tabsintitlebar="true"][sizemode="maximized"] #toolbar-menubar { /* [tabsi
 }
 
 #tt-toolbar > toolbarbutton {
+	-moz-binding: url("chrome://tabtree/content/bindings.xml#toolbarbutton-overlay");
 	-moz-appearance: none; /* This is needed to permit changing the background of the buttons */
 }
 
@@ -21,4 +25,39 @@ window[tabsintitlebar="true"][sizemode="maximized"] #toolbar-menubar { /* [tabsi
 	background-position:  center bottom var(--tab-toolbar-navbar-overlap);
 	background-repeat: no-repeat;
 	background-size: 85% 100%;
+}
+
+
+/* :::::: toolbarbutton-overlay style :::::: */
+/* Much inspiration taken from chrome://global/skin/toolbarbutton.css */
+
+#tt-toolbar > toolbarbutton .toolbarbutton-icon {
+	width: 16px !important;
+	height: 16px !important;
+}
+
+#tt-toolbar > toolbarbutton:not([overlay]) .toolbarbutton-overlay {
+	display: none;
+}
+
+#tt-toolbar > toolbarbutton[overlay] .toolbarbutton-overlay {
+	display: -moz-box;
+	margin: -6px 0 0 !important;
+	-moz-margin-end: -6px !important;
+	width: 14px !important;
+	height: 14px !important;
+	background-color: #000000;
+	border-radius: 6px;
+}
+
+#tt-toolbar > toolbarbutton[overlay] .toolbarbutton-overlay:hover {
+	background-color: #d900d9 !important;
+}
+
+#tt-toolbar > toolbarbutton[overlay~="muted"] .toolbarbutton-overlay {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio-muted);
+}
+
+#tt-toolbar > toolbarbutton[overlay~="soundplaying"] .toolbarbutton-overlay {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio);
 }

--- a/skin/tt-TabsToolbar.css
+++ b/skin/tt-TabsToolbar.css
@@ -15,49 +15,53 @@ window[tabsintitlebar="true"][sizemode="maximized"] #toolbar-menubar { /* [tabsi
 	visibility: collapse;
 }
 
-#tt-toolbar > toolbarbutton {
-	-moz-binding: url("chrome://tabtree/content/bindings.xml#toolbarbutton-overlay");
+/* :::::: ttpinnedtab style :::::: */
+
+ttpinnedtab {
+	-moz-binding: url("chrome://tabtree/content/bindings.xml#ttpinnedtab");
+}
+
+.tt-tab-overlay:not([overlay]) {
+	display: none;
+}
+
+.tt-tab-overlay[overlay] {
+	display: -moz-box;
+	width: 16px !important;
+	height: 16px !important;
+	background-color: transparent;
+	border-radius: 9px;
+}
+
+.tt-tab-overlay[overlay]:hover {
+	background-color: white;
+}
+
+.tt-tab-overlay[overlay~="muted"] {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio-muted);
+}
+
+.tt-tab-overlay[overlay~="soundplaying"] {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio);
+}
+
+/* :::::: ttbutton style :::::: */
+/* This is really just a toolbarbutton with a few added methods */
+
+toolbarbutton.tt-tab-button {
+	-moz-binding: url("chrome://tabtree/content/bindings.xml#ttbutton");
 	-moz-appearance: none; /* This is needed to permit changing the background of the buttons */
 }
 
-#tt-toolbar > toolbarbutton[titlechanged] {
+toolbarbutton.tt-tab-button[titlechanged] {
 	background-image: radial-gradient(farthest-corner at center bottom , rgb(255, 255, 255) 3%, rgba(186, 221, 251, 0.75) 20%, rgba(127, 179, 255, 0.25) 40%, transparent 70%);
 	background-position:  center bottom var(--tab-toolbar-navbar-overlap);
 	background-repeat: no-repeat;
 	background-size: 85% 100%;
 }
 
-
-/* :::::: toolbarbutton-overlay style :::::: */
-/* Much inspiration taken from chrome://global/skin/toolbarbutton.css */
-
-#tt-toolbar > toolbarbutton .toolbarbutton-icon {
+toolbarbutton.tt-tab-button > image {
 	width: 16px !important;
 	height: 16px !important;
 }
 
-#tt-toolbar > toolbarbutton:not([overlay]) .toolbarbutton-overlay {
-	display: none;
-}
-
-#tt-toolbar > toolbarbutton[overlay] .toolbarbutton-overlay {
-	display: -moz-box;
-	margin: -6px 0 0 !important;
-	-moz-margin-end: -6px !important;
-	width: 14px !important;
-	height: 14px !important;
-	background-color: #000000;
-	border-radius: 6px;
-}
-
-#tt-toolbar > toolbarbutton[overlay] .toolbarbutton-overlay:hover {
-	background-color: #d900d9 !important;
-}
-
-#tt-toolbar > toolbarbutton[overlay~="muted"] .toolbarbutton-overlay {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio-muted);
-}
-
-#tt-toolbar > toolbarbutton[overlay~="soundplaying"] .toolbarbutton-overlay {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio);
-}

--- a/skin/tt-TabsToolbar.css
+++ b/skin/tt-TabsToolbar.css
@@ -21,11 +21,12 @@ ttpinnedtab {
 	-moz-binding: url("chrome://tabtree/content/bindings.xml#ttpinnedtab");
 }
 
-.tt-tab-overlay:not([overlay]) {
+.tt-tab-overlay:not([muted]):not([soundplaying]) {
 	display: none;
 }
 
-.tt-tab-overlay[overlay] {
+.tt-tab-overlay[muted],
+.tt-tab-overlay[soundplaying] {
 	display: -moz-box;
 	width: 16px !important;
 	height: 16px !important;
@@ -33,17 +34,19 @@ ttpinnedtab {
 	border-radius: 9px;
 }
 
-.tt-tab-overlay[overlay]:hover {
+.tt-tab-overlay[muted]:hover,
+.tt-tab-overlay[soundplaying]:hover {
 	background-color: white;
 }
 
-.tt-tab-overlay[overlay~="muted"] {
+.tt-tab-overlay[soundplaying] {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio);
+}
+
+.tt-tab-overlay[muted] {
 	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio-muted);
 }
 
-.tt-tab-overlay[overlay~="soundplaying"] {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio-small.svg#tab-audio);
-}
 
 /* :::::: ttbutton style :::::: */
 /* This is really just a toolbarbutton with a few added methods */

--- a/skin/tt-tree.css
+++ b/skin/tt-tree.css
@@ -118,11 +118,11 @@
 
 /* :::::: Close button icons ::::: */
 
-#tt #tt-col-2 { /* assuming 17px scrollbar width */
+#tt #tt-close { /* assuming 17px scrollbar width */
 	width: 35px;
 }
 
-#tt[hidevscroll] #tt-col-2 {
+#tt[hidevscroll] #tt-close {
 	width: 18px;
 }
 
@@ -148,6 +148,34 @@
 #tt-treechildren::-moz-tree-image(tt-close, hover) {
 	list-style-image: url(chrome://tabtree/skin/close.png);
 	-moz-image-region: rect(0, 32px, 16px, 16px);
+}
+
+/* :::::: Icons to simulate tab-overlay icons ::::: */
+
+#tt #tt-overlay {
+	width: 18px;
+}
+
+#tt-treechildren::-moz-tree-image(tt-overlay, tt-playing) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu);
+}
+
+#tt-treechildren::-moz-tree-image(tt-overlay, tt-playing, hover) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-hover);
+}
+
+#tt-treechildren::-moz-tree-image(tt-overlay, tt-muted) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-muted);
+}
+
+#tt-treechildren::-moz-tree-image(tt-overlay, tt-muted, hover) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-muted-hover);
+}
+
+#tt-treechildren::-moz-tree-image(tt-overlay) {
+	padding-right: 0px;
+	margin: 0 0px;
+	list-style-image: none;
 }
 
 /* Tab search box */

--- a/skin/tt-tree.css
+++ b/skin/tt-tree.css
@@ -156,6 +156,10 @@
 	width: 18px;
 }
 
+#tt[hideclosebuttons]:not([hidevscroll]) #tt-overlay { /* assuming 17px scrollbar width */
+    width: 35px;
+}
+
 #tt-treechildren:-moz-tree-cell(tt-overlay),
 #tt-treechildren:-moz-tree-image(tt-overlay),
 #tt-treechildren-feedback:-moz-tree-cell(tt-overlay),

--- a/skin/tt-tree.css
+++ b/skin/tt-tree.css
@@ -156,26 +156,38 @@
 	width: 18px;
 }
 
-#tt-treechildren::-moz-tree-image(tt-overlay, tt-playing) {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu);
+#tt-treechildren:-moz-tree-cell(tt-overlay),
+#tt-treechildren:-moz-tree-image(tt-overlay),
+#tt-treechildren-feedback:-moz-tree-cell(tt-overlay),
+#tt-treechildren-feedback:-moz-tree-image(tt-overlay) {
+	margin: 0;
+	padding: 0;
 }
 
-#tt-treechildren::-moz-tree-image(tt-overlay, tt-playing, hover) {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-hover);
-}
-
-#tt-treechildren::-moz-tree-image(tt-overlay, tt-muted) {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-muted);
-}
-
-#tt-treechildren::-moz-tree-image(tt-overlay, tt-muted, hover) {
-	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-menu-muted-hover);
-}
-
+/* This rule has to come before the following ones, or else it
+ * overrides them */
 #tt-treechildren::-moz-tree-image(tt-overlay) {
-	padding-right: 0px;
-	margin: 0 0px;
 	list-style-image: none;
+}
+
+#tt-treechildren::-moz-tree-image(tt-soundplaying),
+#tt-treechildren-feedback::-moz-tree-image(tt-soundplaying) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio);
+}
+
+#tt-treechildren::-moz-tree-image(tt-soundplaying, hover),
+#tt-treechildren-feedback::-moz-tree-image(tt-soundplaying, hover) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-hover);
+}
+
+#tt-treechildren::-moz-tree-image(tt-muted),
+#tt-treechildren-feedback::-moz-tree-image(tt-muted) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-muted);
+}
+
+#tt-treechildren::-moz-tree-image(tt-muted, hover),
+#tt-treechildren-feedback::-moz-tree-image(tt-muted, hover) {
+	list-style-image: url(chrome://browser/skin/tabbrowser/tab-audio.svg#tab-audio-muted-hover);
 }
 
 /* Tab search box */

--- a/skin/tt-tree.css
+++ b/skin/tt-tree.css
@@ -116,13 +116,22 @@
 	border: 1px solid #EF0FFF; /* default Firefox color for "Highlight all" option in <findbar> */
 }
 
-/* :::::: Close button icons ::::: */
-
-#tt #tt-close { /* assuming 17px scrollbar width */
-	width: 35px;
+/* :::::: Space for scrollbar ::::: */
+#tt #tt-scrollbar {
+	width: 17px;    /* assuming this width of scrollbar */
+	list-style-image: none;
+	visibility: visible;
 }
 
-#tt[hidevscroll] #tt-close {
+#tt[hidevscroll] #tt-scrollbar {
+	width: 0px;
+	visibility: collapse;
+}
+
+
+/* :::::: Close button icons ::::: */
+
+#tt #tt-close {
 	width: 18px;
 }
 
@@ -154,10 +163,6 @@
 
 #tt #tt-overlay {
 	width: 18px;
-}
-
-#tt[hideclosebuttons]:not([hidevscroll]) #tt-overlay { /* assuming 17px scrollbar width */
-    width: 35px;
 }
 
 #tt-treechildren:-moz-tree-cell(tt-overlay),


### PR DESCRIPTION
This grew a fair bit bigger than I expected. I'll understand if you think this is too drastic a change to include. But hopefully you'll at least get some interesting ideas from it.

Audio indicators for non-pinned tabs was pretty straightforward. I added a column to the tabtree to hold and display the indicator. Most of the related work around that was to undo the now-inaccurate assumption throughout the code that there are only two columns, the tab label and the close button.

(I also added tooltip logic to the tabtree, so that mousing over the audio indicator would show the same tooltip that appears on Firefox's tab indicator.)

Things get drastic when it comes to adding the indicator to pinned tabs. A simple toolbarbutton wasn't enough to do the trick. Rather than making redrawToolbarButtons() more complicated, I decided to create an XBL binding to encapsulate the XUL stack+toolbarbutton+image combo that makes up the indicator. That's in bindings.xml, and it gets "activated" by the -moz-binding CSS property in skin/tt-TabsToolbar.css.

A (hopefully minor) downside to this approach is it complicates drag-drop on the toolbar a bit, since the toolbarbutton is no longer a direct child of the toolbar. (It also has a xul: prefix to its tag name in some places now.) I tried to keep the code straightforward and add comments to affected parts of the code.

Encapsulating the XUL elements was so much fun, I decided to encapsulate the javascript as well. A bunch of the redraw logic from redrawToolbarButtons() has been moved into bindings.xml, into the repaint() method. I think it makes the code easier to read in the long run. Hopefully the move to XBL doesn't impact the performance of the add-on.
