### PR TITLE
Changed the double-click option from bool to int, added pin/unpin toggle

### DIFF
--- a/locale/en-US/options.dtd
+++ b/locale/en-US/options.dtd
@@ -16,8 +16,11 @@
 <!ENTITY highlight-unread-tabs.desc "(unchecked by default)">
 <!ENTITY tab-numbers.title "Show tab numbers in tab titles:">
 <!ENTITY tab-numbers.desc "Useful for Vim-style add-ons (unchecked by default)">
-<!ENTITY dblclick.title "Double click to close a tab">
+<!ENTITY dblclick.title "Double click to close or pin a tab">
 <!ENTITY dblclick.desc "Only recommended if you don't have a mouse with a wheel (unchecked by default)">
+<!ENTITY dblclick.none "None">
+<!ENTITY dblclick.close "Close tab">
+<!ENTITY dblclick.pin "Pin tab">
 <!ENTITY middle-click-tabbar.title "Middle-click on the tabbar:">
 <!ENTITY middle-click-tabbar.desc "(&#171;Firefox default&#187; by default)">
 <!ENTITY middle-click-tabbar.0 "Firefox default (open a new tab)">

--- a/options.xul
+++ b/options.xul
@@ -33,7 +33,13 @@
     </setting>
     <setting type="bool" pref="extensions.tabtree.highlight-unread-tabs" title="&highlight-unread-tabs.title;" desc="&highlight-unread-tabs.desc;" />
     <setting type="bool" pref="extensions.tabtree.tab-numbers" title="&tab-numbers.title;" desc="&tab-numbers.desc;" />
-    <setting type="bool" pref="extensions.tabtree.dblclick" title="&dblclick.title;" desc="&dblclick.desc;" onpreferencechanged="this.setAttribute('value', this.value.toString());" />
+    <setting type="radio" pref="extensions.tabtree.dblclick" title="&dblclick.title;" desc="&dblclick.desc;" >
+        <radiogroup>
+            <radio value="0" label="&dblclick.none;"/>
+            <radio value="1" label="&dblclick.close;"/>
+            <radio value="2" label="&dblclick.pin;"/>
+        </radiogroup>
+    </setting>
     <setting type="integer" pref="extensions.tabtree.delay" title="&delay.title;" desc="&delay.desc;" />
     <setting type="menulist" pref="extensions.tabtree.middle-click-tabbar" title="&middle-click-tabbar.title;" desc="&middle-click-tabbar.desc;">
         <menulist>


### PR DESCRIPTION
Maybe [I'm just weird](https://xkcd.com/1172/), but I'm a big fan of the "pin/unpin tab" event handler in Tab Mix Plus. I have it set to trigger on double-click, and it's a nice way to pick one or two "keepers" out of a big tree of tabs before I close the rest of them.

I couldn't see how to attach or propagate double clicks on tabs in the tree panel to the default handler (i.e., the one I have set in TMP), so I reimplemented the feature as an option on the existing dblclick preference.

Does that seem generally useful? I can just use a keyboard shortcut if not, no big deal either way.
