### PR TITLE
Quick search should have some way of jumping to matches (proposed fix included)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2537,14 +2537,7 @@ var windowListener = {
 
 		// Enter in quick search box = jump to first tab matching quick search
 		quickSearchBox.onkeydown = function(keyboardEvent) {
-			if (keyboardEvent.key=='Escape') {
-				if (Services.prefs.getBoolPref('extensions.tabtree.search-autohide')) {
-					quickSearchBox.collapsed = true;
-				} else {
-					quickSearchBox.value = '';
-					tree.treeBoxObject.invalidate();
-				}
-			} else if (keyboardEvent.key=='Enter') {
+			if (keyboardEvent.key=='Enter') {
 				let txt = quickSearchBox.value.toLowerCase();
 				for (let tPos = g._numPinnedTabs; tPos < g.tabs.length; ++tPos) {
 					let url = g.browsers[tPos]._userTypedValue || g.browsers[tPos].contentDocument.URL || '';
@@ -2555,7 +2548,14 @@ var windowListener = {
 						break;
 					}
 				}
-	 
+			}
+			if (keyboardEvent.key=='Enter' || keyboardEvent.key=='Escape') {
+				if (Services.prefs.getBoolPref('extensions.tabtree.search-autohide')) {
+					quickSearchBox.collapsed = true;
+				} else {
+					quickSearchBox.value = '';
+					tree.treeBoxObject.invalidate();
+				}
 			}
 		};
 

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2524,7 +2524,7 @@ var windowListener = {
 			tree.treeBoxObject.invalidate();
 		}, false);
 
-		tree.onkeydown = quickSearchBox.onkeydown = function(keyboardEvent) {
+		tree.onkeydown = function(keyboardEvent) {
 			if (keyboardEvent.key=='Escape') {
 				if (Services.prefs.getBoolPref('extensions.tabtree.search-autohide')) {
 					quickSearchBox.collapsed = true;
@@ -2532,6 +2532,30 @@ var windowListener = {
 					quickSearchBox.value = '';
 					tree.treeBoxObject.invalidate();
 				}
+			}
+		};
+
+		// Enter in quick search box = jump to first tab matching quick search
+		quickSearchBox.onkeydown = function(keyboardEvent) {
+			if (keyboardEvent.key=='Escape') {
+				if (Services.prefs.getBoolPref('extensions.tabtree.search-autohide')) {
+					quickSearchBox.collapsed = true;
+				} else {
+					quickSearchBox.value = '';
+					tree.treeBoxObject.invalidate();
+				}
+			} else if (keyboardEvent.key=='Enter') {
+				let txt = quickSearchBox.value.toLowerCase();
+				for (let tPos = g._numPinnedTabs; tPos < g.tabs.length; ++tPos) {
+					let url = g.browsers[tPos]._userTypedValue || g.browsers[tPos].contentDocument.URL || '';
+					// 'url.toLowerCase()' may be replaced by 'url':
+					if (g.tabs[tPos].label.toLowerCase().indexOf(txt) != -1 || url.toLowerCase().indexOf(txt) != -1) {
+						g.selectTabAtIndex(tPos);
+						quickSearchBox.focus();
+						break;
+					}
+				}
+	 
 			}
 		};
 


### PR DESCRIPTION
As it stands right now, the only way to make the quick search bar jump to a matching tab seems to be to enable the flag that makes it do so automatically when a set number of characters has been typed. This is unwieldy, and I'd much prefer if there were some way of triggering the jump explicitly. I am attaching a somewhat crude fix that worked for me (pressing enter in the quick search bar jumps to the first matching tab); an argument for it is that [rofi](https://davedavenport.github.io/rofi/), as a canonical "quick search for making named selections" app, also uses that convention.
