### PR TITLE
Remove outdated comment about MDN discrepancy

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1883,7 +1883,7 @@ var windowListener = {
 				) {
 					g.tabContainer.addEventListener('TabOpen', function onPreAddTabWithoutRef(event) {
 						g.tabContainer.removeEventListener('TabOpen', onPreAddTabWithoutRef, true);
-						if ( ss.getTabValue(event.target, 'ttLevel') === '' ) { // despite MDN it returns '' instead of undefined
+						if ( ss.getTabValue(event.target, 'ttLevel') === '' ) {
 							ss.setTabValue(event.target, 'ttLevel', '0');
 						}
 						tree.treeBoxObject.rowCountChanged(event.target._tPos-tt.nPinned, 1);


### PR DESCRIPTION
MDN’s documentation for `getTabValue` at https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsISessionStore#getTabValue() now correctly states that the function returns “an empty string if no value is set for that key”. So there is no discrepancy that needs to be documented in a comment.
